### PR TITLE
Switch API endpoint to /v3/shorten

### DIFF
--- a/Tests/Shivella/Bitly/Client/response.json
+++ b/Tests/Shivella/Bitly/Client/response.json
@@ -1,1 +1,1 @@
-{"status_code": 200, "data": {"link_lookup": [{"url": "http://www.nu.nl/", "aggregate_link": "http://bit.ly/1nRtGA"}]}, "status_txt": "OK"}
+{"status_code":200,"status_txt":"OK","data":{"url":"http://bit.ly/1nRtGA","hash":"2nk8zqP","global_hash":"SmaYx","long_url":"http://www.laravel.com/","new_hash":1}}

--- a/Tests/Shivella/Bitly/Client/response_statuscode.json
+++ b/Tests/Shivella/Bitly/Client/response_statuscode.json
@@ -1,1 +1,1 @@
-{"status_code": 503, "data": {"link_lookup": [{"url": "http://www.nu.nl/", "aggregate_link": "http://bit.ly/1nRtGA"}]}, "status_txt": "OK"}
+{"status_code":503,"status_txt":"OK","data":{"url":"http://bit.ly/2nk8zqP","hash":"2nk8zqP","global_hash":"SmaYx","long_url":"http://www.laravel.com/","new_hash":1}}

--- a/src/Shivella/Bitly/Client/BitlyClient.php
+++ b/src/Shivella/Bitly/Client/BitlyClient.php
@@ -52,7 +52,7 @@ class BitlyClient
         }
 
         try {
-            $requestUrl = sprintf('https://api-ssl.bitly.com/v3/link/lookup?url=%s&access_token=%s', $url, $this->token);
+            $requestUrl = sprintf('https://api-ssl.bitly.com/v3/shorten?longUrl=%s&access_token=%s', $url, $this->token);
             $response = $this->client->send(new Request('GET', $requestUrl));
 
             if ($response->getStatusCode() === Response::HTTP_FORBIDDEN) {
@@ -65,15 +65,15 @@ class BitlyClient
 
             $data = json_decode($response->getBody()->getContents(), true);
 
-            if (false === isset($data['data']['link_lookup'][0]['aggregate_link'])) {
-                throw new InvalidResponseException('The response does not contain a aggregate link');
+            if (false === isset($data['data']['url'])) {
+                throw new InvalidResponseException('The response does not contain a shortened link');
             }
 
             if ($data['status_code'] !== Response::HTTP_OK) {
                 throw new InvalidResponseException('The API does not return a 200 status code');
             }
 
-            return $data['data']['link_lookup'][0]['aggregate_link'];
+            return $data['data']['url'];
 
         } catch (\Exception $exception) {
             throw new InvalidResponseException($exception->getMessage());


### PR DESCRIPTION
The correct endpoint is /v3/shorten, not /v3/link/lookup. Using the latter will result in errors for links that have never been shortened (by anyone on Bitly).