### PR TITLE
Upgraded Bitly API to V4

### DIFF
--- a/Tests/Shivella/Bitly/Client/BitlyClientTest.php
+++ b/Tests/Shivella/Bitly/Client/BitlyClientTest.php
@@ -58,7 +58,7 @@ class BitlyClientTest extends TestCase
             ->method('getContents')
             ->willReturn(file_get_contents(__DIR__ . '/response.json'));
 
-        $this->assertSame('http://bit.ly/1nRtGA', $this->bitlyClient->getUrl('https://www.test.com/foo'));
+        $this->assertSame('http://bit.ly/1VmfKqV', $this->bitlyClient->getUrl('https://www.test.com/foo'));
     }
 
     public function testGetUrlInvalidResponseException() : void

--- a/Tests/Shivella/Bitly/Client/response.json
+++ b/Tests/Shivella/Bitly/Client/response.json
@@ -1,1 +1,1 @@
-{"status_code":200,"status_txt":"OK","data":{"url":"http://bit.ly/1nRtGA","hash":"2nk8zqP","global_hash":"SmaYx","long_url":"http://www.laravel.com/","new_hash":1}}
+{"created_at":"1970-01-01T00:00:00+0000","id":"bit.ly/1VmfKqV","link":"http://bit.ly/1VmfKqV","custom_bitlinks":[],"long_url":"http://www.laravel.com","archived":false,"tags":[],"deeplinks":[],"references":{"group":""}}

--- a/src/Shivella/Bitly/Client/BitlyClient.php
+++ b/src/Shivella/Bitly/Client/BitlyClient.php
@@ -54,9 +54,9 @@ class BitlyClient
     public function getUrl(string $url) : string
     {
         try {
-            $requestUrl = sprintf('https://api-ssl.bitly.com/v4/shorten');
+            $requestUrl = 'https://api-ssl.bitly.com/v4/shorten';
             $response = $this->client->send(
-                new Request('GET', $requestUrl, [
+                new Request('POST', $requestUrl, [
                     'json' => ['long_url' => $url]
                 ]),
                 ['headers' => $this->header]

--- a/src/Shivella/Bitly/Client/BitlyClient.php
+++ b/src/Shivella/Bitly/Client/BitlyClient.php
@@ -26,6 +26,9 @@ class BitlyClient
     /** @var string $token */
     private $token;
 
+    /** @var array $header */
+    private $header;
+
     /**
      * @param ClientInterface $client
      * @param string          $token
@@ -33,7 +36,11 @@ class BitlyClient
     public function __construct(ClientInterface $client, string $token)
     {
         $this->client = $client;
-        $this->token  = $token;
+        $this->token = $token;
+        $this->header = [
+            'Authorization' => 'Bearer '.$token,
+            'Content-Type' => 'application/json',
+        ];
     }
 
     /**
@@ -47,8 +54,13 @@ class BitlyClient
     public function getUrl(string $url) : string
     {
         try {
-            $requestUrl = sprintf('https://api-ssl.bitly.com/v3/shorten?longUrl=%s&access_token=%s', $url, $this->token);
-            $response = $this->client->send(new Request('GET', $requestUrl));
+            $requestUrl = sprintf('https://api-ssl.bitly.com/v4/shorten');
+            $response = $this->client->send(
+                new Request('GET', $requestUrl, [
+                    'json' => ['long_url' => $url]
+                ]),
+                ['headers' => $this->header]
+            );
 
             if ($response->getStatusCode() === Response::HTTP_FORBIDDEN) {
                 throw new AccessDeniedException('Invalid access token');
@@ -60,19 +72,11 @@ class BitlyClient
 
             $data = json_decode($response->getBody()->getContents(), true);
 
-            if (isset($data['status_txt']) && $data['status_txt'] === 'RATE_LIMIT_EXCEEDED') {
-		        throw new InvalidResponseException('You have reached the API rate limit, please try again later');
-            }
-
-            if (false === isset($data['data']['url'])) {
+            if (false === isset($data['link'])) {
                 throw new InvalidResponseException('The response does not contain a shortened link');
             }
 
-            if ($data['status_code'] !== Response::HTTP_OK) {
-                throw new InvalidResponseException('The API does not return a 200 status code');
-            }
-
-            return $data['data']['url'];
+            return $data['link'];
 
         } catch (Exception $exception) {
             throw new InvalidResponseException($exception->getMessage());


### PR DESCRIPTION
I have upgraded the API endpoint to the [V4 version](https://dev.bitly.com/v4_documentation.html#section/Migrating-from-V3), because the V3 API will be deactivated on March 2020.

The new API is using header token as its authentication method; therefore I have moved the token to the request header. The new API also returns a different json response, therefore I have updated the response.json for testing.