### PR TITLE
Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Ignore all test and documentation for archive
+/.github            export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/tests              export-ignore


### PR DESCRIPTION
Added `.gitattributes` with 'export-ignore' directive. This will reduce the size of future tags, removing redundant files from them.