### PR TITLE
Fix DI injection is broken in case of `BitlyClientFake` usage

### DIFF
--- a/src/Testing/BitlyClientFake.php
+++ b/src/Testing/BitlyClientFake.php
@@ -2,6 +2,8 @@
 
 namespace Shivella\Bitly\Testing;
 
+use Shivella\Bitly\Client\BitlyClient;
+
 /**
  * BitlyClientFake is a mock for the regular Bitly client.
  *
@@ -13,8 +15,15 @@ namespace Shivella\Bitly\Testing;
  * @see \Shivella\Bitly\Client\BitlyClient
  * @see \Shivella\Bitly\Facade\Bitly::fake()
  */
-class BitlyClientFake
+class BitlyClientFake extends BitlyClient
 {
+    public function __construct()
+    {
+        // Unlike with other methods, PHP will not generate an E_STRICT level error message when __construct() is overridden
+        // with different parameters than the parent __construct() method has.
+        // @see https://www.php.net/manual/en/language.oop5.decon.php
+    }
+
     /**
      * @param string $url raw URL.
      * @return string shorten URL.


### PR DESCRIPTION
In case implicit DI binding for `BitlyClient` is used:

```php
public function (BitlyClient $bitly)
{
    // ...
}
```
swapping it with `BitlyClientFake` produces a PHP error about object type missmatch.

This PR makes `BitlyClientFake` to directly extend `BitlyClient`, preventing such problems.