### PR TITLE
Add ability to add a title to bitly shorten links using create method instead of getUrl

### DIFF
--- a/src/Client/BitlyClient.php
+++ b/src/Client/BitlyClient.php
@@ -63,6 +63,7 @@ class BitlyClient
             'domain' => $domain,
             'group_guid' => $group_guid,
         ]);
+        if($title) $data['title'] = $title;
 
         try {
             $request = new Request('POST', $requestUrl, $header, json_encode($data));

--- a/src/Client/BitlyClient.php
+++ b/src/Client/BitlyClient.php
@@ -49,9 +49,9 @@ class BitlyClient
      * @throws \Shivella\Bitly\Exceptions\AccessDeniedException
      * @throws \Shivella\Bitly\Exceptions\InvalidResponseException
      */
-    public function getUrl(string $url, ?string $domain = null, ?string $group_guid = null): string
+    public function getUrl(string $url, ?string $domain = null, ?string $group_guid = null, ?string $title = null, $requestUrl = 'https://api-ssl.bitly.com/v4/shorten'): string
     {
-        $requestUrl = 'https://api-ssl.bitly.com/v4/shorten';
+        ## $requestUrl = 'https://api-ssl.bitly.com/v4/shorten';
 
         $header = [
             'Authorization' => 'Bearer ' . $this->token,
@@ -98,5 +98,8 @@ class BitlyClient
         }
 
         throw new InvalidResponseException('The response does not contain a shortened link. Response: '.$content);
+    }
+    public function create(string $url, ?string $title = null, ?string $domain = null, ?string $group_guid = null){
+        return $this->getUrl($url, $domain, $group_guid , $title, 'https://api-ssl.bitly.com/v4/bitlinks');
     }
 }

--- a/src/Facade/Bitly.php
+++ b/src/Facade/Bitly.php
@@ -17,6 +17,7 @@ use Shivella\Bitly\Testing\BitlyClientFake;
  * @see \Shivella\Bitly\Client\BitlyClient
  *
  * @method string getUrl(string $url)
+ * @method string create(string $url, string $title)
  */
 class Bitly extends Facade
 {


### PR DESCRIPTION
`Bitly::create('http://url.com/, 'title', 'domain.com');`